### PR TITLE
Add callback for completed PINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,83 @@ export class HomePage {
 
 ```
 
+pinHandler example
+```typescript
+import { Component } from '@angular/core';
+
+import { NavController } from 'ionic-angular';
+import { AlertController } from 'ionic-angular/components/alert/alert-controller';
+import { PincodeController } from  'ionic2-pincode-input/dist/pincode'
+import { PincodePinHandler } from 'ionic2-pincode-input/dist/pincode-options';
+
+@Component({
+  selector: 'page-home',
+  templateUrl: 'home.html'
+})
+export class HomePage {
+
+  code:string;
+  correctPin: string;
+
+  constructor(
+    public navCtrl: NavController,
+    public pincodeCtrl: PincodeController,
+    public alertCtrl: AlertController
+  ) {
+      // Get your valid PIN here.
+      let correctPin = '1234';
+  }
+
+  handlePIN(outerThis: HomePage): PincodePinHandler {
+
+    return function(enteredPin: string): Promise<any> {
+      this.code = enteredPin;
+      return new Promise<any>((resolve, reject) => {
+        if (enteredPin != outerThis.correctPin) {
+          // PIN is wrong!
+          let alert = outerThis.alertCtrl.create({
+            title: 'Incorrect PIN',
+            subTitle: "The PIN you entered is incorrect.",
+            buttons: [{ text: 'OK', handler: data => { } }]
+          });
+
+          alert.present();
+
+          alert.onDidDismiss(() => { reject() });
+        } else {
+          // PIN is correct
+          // Navigate to wherever you want to go.
+          outerThis.navCtrl.setRoot(HomePage);
+
+          resolve();
+        }
+      });
+    }
+  }
+  
+  openPinCode():any{
+
+    let pinCode =  this.pincodeCtrl.create({
+      title:'Pincode',
+      pinHandler: this.handlePIN(this);
+    });
+
+    pinCode.present();
+
+    pinCode.onDidDismiss( (code,status) => {
+
+      if (status === 'forgot'){
+
+        // forgot password
+      }
+
+    })
+
+  }
+
+}
+
+```
 
 ## create(PincodeOpt)
 
@@ -107,6 +184,7 @@ export class HomePage {
 | hideForgotPassword| Boolean     | `false`       | is hide forgot password button   |
 | hideCancelButton | Boolean     | `false`       | is hide cancel button   |
 | enableBackdropDismiss| Boolean     | `true`       | Whether the alert should be dismissed by tapping the backdrop.  |
+| pinHandler| PincodePinHandler `(pin: string): Promise<any>`    | `null`       | Callback called when the PIN is complete. Returns a Promise which resolves if the PIN is valid.  |
 
 [npm-url]: https://www.npmjs.com/package/ionic2-pincode-input
 [npm-image]: https://img.shields.io/npm/v/ionic2-pincode-input.svg

--- a/src/pincode-component.ts
+++ b/src/pincode-component.ts
@@ -183,7 +183,21 @@ export class PincodeCmp {
             this.codeArr[emptyIndex] = num;
         } else if (emptyIndex === this.maxLen - 1) {
             this.codeArr[emptyIndex] = num;
-            this.dismiss('done')
+            // If we have a completed PIN handler,
+            // call it with the completed PIN.
+            if (this.d.pinHandler) {
+                this.d.pinHandler(this.getValues())
+                    .then(() => {
+                        // PIN is valid.
+                        this.dismiss('done');
+                    })
+                    .catch(() => {
+                        // PIN is invalid.
+                        this.restoreClick();
+                    });
+            } else {
+                this.dismiss('done');
+            }
         }
     }
 

--- a/src/pincode-options.ts
+++ b/src/pincode-options.ts
@@ -1,4 +1,11 @@
-
+// A function to handle a completed PIN.
+// The function takes the completed PIN as a parameter,
+// and returns a Promise which resolves if the PIN is valid,
+// or rejects if the PIN is invalid.
+export interface PincodePinHandler {
+    (pin: string): Promise<any>
+}
+    
 export interface PincodeOpt {
     title?:string,
     cancelButtonText?:string,
@@ -9,5 +16,6 @@ export interface PincodeOpt {
     cssClass?:string,
     encoded?:Function,
     passSize?:number,
-    hideToolbar?: boolean
+    hideToolbar?: boolean,
+    pinHandler?: PincodePinHandler
 }


### PR DESCRIPTION
Feature is to add a callback function to the Pincode options which is called when the PIN is completed. The client handler can validate the PIN, and if it is incorrect, display an error message and then leave the PIN entry visible for the user to retry the PIN, without dismissing the component.

I updated the Readme.md with an example.