### PR TITLE
chore: import animations from new angular package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/HsuanXyz/ionic2-pincode-input.git"
   },
   "devDependencies": {
+    "@angular/animations": "^5.2.9",
     "@angular/common": "^5.2.9",
     "@angular/compiler": "^5.2.9",
     "@angular/compiler-cli": "^5.2.9",
@@ -24,13 +25,12 @@
     "@angular/platform-browser": "^5.2.9",
     "@angular/platform-browser-dynamic": "^5.2.9",
     "@angular/platform-server": "^5.2.9",
+    "gulp": "^3.9.1",
     "ionic-angular": "3.9.2",
-    "rxjs": "5.5.7",
-    "zone.js": "0.8.20",
-    "typescript": "^2.7.2",
     "ng-packagr": "^2.4.1",
-    "gulp": "^3.9.1"
-
+    "rxjs": "5.5.7",
+    "typescript": "^2.7.2",
+    "zone.js": "0.8.20"
   },
   "keywords": [
     "ionic2",

--- a/src/pincode-component.ts
+++ b/src/pincode-component.ts
@@ -2,11 +2,6 @@ import {
     Component,
     ElementRef,
     ViewEncapsulation,
-    trigger,
-    state,
-    animate,
-    transition,
-    style,
     Renderer2
 } from '@angular/core';
 
@@ -22,6 +17,7 @@ import {
 } from 'ionic-angular';
 import { assert, isNumber } from 'ionic-angular/util/util';
 import { PincodeOpt } from './pincode-options';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 
 @Component({
     selector: 'ion-pincode',


### PR DESCRIPTION
Importing animations from @angular/core is deprecated. Animations should be now imported from the new pagacke @angular/animations.